### PR TITLE
Use `MOCK_PINS_COUNT` instead of `ARDUINO_CI` to identify CI tests

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,15 +1,3 @@
-platforms:
-  mega2560:
-    board: arduino:avr:mega:cpu=atmega2560
-    package: arduino:avr
-    gcc:
-      features:
-      defines:
-        - __AVR_ATmega2560__
-        - ARDUINO_CI
-        - __AVR__
-      warnings:
-      flags:
 
 unittest:
   platforms:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'arduino_ci'
+gem 'arduino_ci', git: 'https://github.com/Arduino-CI/arduino_ci.git', branch: 'master'

--- a/src/SD.h
+++ b/src/SD.h
@@ -53,7 +53,7 @@ namespace SDLib {
       void rewindDirectory(void);
 
       using Print::write;
-#ifdef ARDUINO_CI
+#ifdef MOCK_PINS_COUNT
       int getWriteError() { return writeError; }
       void setWriteError(int value = 1) { writeError = value; }
       void clearWriteError() { writeError = 0; }

--- a/src/utility/Sd2PinMap.cpp
+++ b/src/utility/Sd2PinMap.cpp
@@ -1,4 +1,4 @@
-#ifdef ARDUINO_CI
+#ifdef MOCK_PINS_COUNT
 
 #include <Arduino.h>
 #include "Sd2PinMap.h"

--- a/src/utility/Sd2PinMap.h
+++ b/src/utility/Sd2PinMap.h
@@ -18,20 +18,9 @@
    <http://www.gnu.org/licenses/>.
 */
 
-#ifdef ARDUINO_CI
-  #include <inttypes.h>
-  #ifdef _SFR_IO8
-    #undef _SFR_IO8
-    #define _AVR_IO_REG(type, mem_addr) (*(type*)(&avr_io_registers[mem_addr]))
-    #define __SFR_OFFSET 0x20
-    #define _SFR_IO8(io_addr) _AVR_IO_REG(uint8_t, io_addr + __SFR_OFFSET)
-    #define _SFR_IO16(io_addr) _AVR_IO_REG(uint16_t, io_addr + __SFR_OFFSET)
-    #define _SFR_MEM8(mem_addr) _AVR_IO_REG(uint8_t, mem_addr)
-    #define _SFR_MEM16(mem_addr) _AVR_IO_REG(uint16_t, mem_addr)
-    #define _SFR_MEM32(mem_addr) _AVR_IO_REG(uint32_t, mem_addr)
+#include <Arduino.h>
 
-    extern uint8_t avr_io_registers[RAMSTART];
-  #endif
+#ifdef MOCK_PINS_COUNT
   #define SDCARD_SS_PIN    4
   #define SDCARD_MOSI_PIN 11
   #define SDCARD_MISO_PIN 12
@@ -58,6 +47,13 @@
   #define Sd2PinMap_h
 
   #include <Arduino.h>
+
+  #ifdef MOCK_PINS_COUNT
+    #define SDCARD_SS_PIN    4
+    #define SDCARD_MOSI_PIN 11
+    #define SDCARD_MISO_PIN 12
+    #define SDCARD_SCK_PIN  13
+  #endif
 
   uint8_t const SS_PIN = SS;
   uint8_t const MOSI_PIN = MOSI;

--- a/src/utility/SdFat.h
+++ b/src/utility/SdFat.h
@@ -454,7 +454,7 @@ class SdFile : public Print {
     static uint8_t make83Name(const char* str, uint8_t* name);
     uint8_t openCachedEntry(uint8_t cacheIndex, uint8_t oflags);
     dir_t* readDirCache(void);
-#ifdef ARDUINO_CI
+#ifdef MOCK_PINS_COUNT
     int writeError;
   public:
     int getWriteError() { return writeError; }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,8 +1,8 @@
 /*
 bundle config --local path vendor/bundle
 bundle install
-bundle exec arduino_ci_remote.rb  --skip-compilation
-bundle exec arduino_ci_remote.rb  --skip-unittests
+bundle exec arduino_ci.rb  --skip-examples-compilation
+bundle exec arduino_ci.rb  --skip-unittests
  */
 #include "Arduino.h"
 #include "ArduinoUnitTests.h"


### PR DESCRIPTION
Update to latest `arduino_ci`